### PR TITLE
rewrite newm-cmd

### DIFF
--- a/bin/newm-cmd
+++ b/bin/newm-cmd
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 from typing import Union
 import argparse
 from newm import cmd

--- a/bin/newm-cmd
+++ b/bin/newm-cmd
@@ -5,19 +5,6 @@ from newm import cmd
 from collections.abc import Sequence
 
 
-# Declare new commands, in the following format "command": "description"
-# See main function
-command_without_args: dict[str, str] = {
-    "inhibit-idle": "Prevents newm from going into idle states (dimming the screen)",
-    "config": "Reloads the configuration",
-    "lock": "Locks the screen",
-    "clean": "Removes orphaned states, which can happen, but shouldn't (if you encounter the need for this, please file a bug)",
-    "debug": "Prints out some debug info on the current state of views",
-    "finish-inhibit-idle": "Restore the idle states",
-    "close-launcher": "Close launcher",
-    "unlock": "Unlocks the screen",
-}
-
 # Declare new commands, in the following format:
 # "command": {
 #   "help": "description",
@@ -27,14 +14,38 @@ command_without_args: dict[str, str] = {
 #   }
 # }
 # See main function
-command_needs_args: dict[str, dict[str, Union[str, dict[str, str]]]] = {
+commands: dict[str, dict[str, Union[str, dict[str, str]]]] = {
+    "inhibit-idle": {
+        "help": "Prevents newm from going into idle states (dimming the screen)",
+        "args": {},
+    },
+    "config": {
+        "help": "Reloads the configuration",
+        "args": {},
+    },
+    "lock": {
+        "help": "Locks the screen",
+        "args": {},
+    },
+    "clean": {
+        "help": "Removes orphaned states, which can happen, but shouldn't (if you encounter the need for this, please file a bug)",
+        "args": {},
+    },
+    "debug": {
+        "help": "Prints out some debug info on the current state of views",
+        "args": {},
+    },
+    "unlock": {
+        "help": "Unlocks the screen",
+        "args": {},
+    },
     "open-virtual-output": {
         "help": "opens a new virtual output (see newm-sidecar)",
-        "args": {"name": "newm-cmd open-virtual-output <name>"},
+        "args": {"output_name": "newm-cmd open-virtual-output <name>"},
     },
     "close-virtual-output": {
         "help": "close a virtual output",
-        "args": {"name": "newm-cmd close-virtual-output <name>"},
+        "args": {"output_name": "newm-cmd close-virtual-output <name>"},
     },
 }
 
@@ -43,45 +54,35 @@ def main(argv: Sequence[str] | None = None) -> int:
     parser = argparse.ArgumentParser()
     subparsers = parser.add_subparsers(dest="command", required=True)
 
-    for command, help in command_without_args.items():
-        subparsers.add_parser(command, help=help)
-
-    for command, meta in command_needs_args.items():
+    for command, meta in commands.items():
         command_parser = subparsers.add_parser(command, help=meta["help"])
         for argument, help in meta["args"].items():
             command_parser.add_argument(argument, help=help)
 
     args = parser.parse_args(argv)
 
-    if args.command in command_without_args.keys():
-        return call_without_args(args.command)
-    elif args.command in command_needs_args.keys():
+    if args.command in commands.keys():
         dict_args = vars(args)
         # dict_args[a] for a in command_needs_args[args.command]["args"].keys()
-        call_with_args(
+        call_cmd(
             args.command,
             *tuple(
                 filter(
                     lambda v: v is not None,
                     map(
                         lambda k: dict_args.get(k, None),
-                        command_needs_args[args.command]["args"].keys(),
+                        commands[args.command]["args"].keys(),
                     ),
                 )
             ),
         )
     else:
         raise NotImplementedError(
-            f"Command {args.command} does not exist.",
+            f"Command {args.command} does not exist, see: newm-cmd -h.",
         )
 
 
-def call_without_args(command: str) -> int:
-    cmd(command)
-    return 0
-
-
-def call_with_args(command: str, *args) -> int:
+def call_cmd(command: str, *args) -> int:
     cmd(command, *args)
     return 0
 

--- a/bin/newm-cmd
+++ b/bin/newm-cmd
@@ -1,5 +1,90 @@
-#!/usr/bin/env python3
-import sys
+#!/usr/bin/env python
+from typing import Union
+import argparse
 from newm import cmd
-if len(sys.argv) > 1:
-    cmd(*sys.argv[1:])
+from collections.abc import Sequence
+
+
+# Declare new commands, in the following format "command": "description"
+# See main function
+command_without_args: dict[str, str] = {
+    "inhibit-idle": "Prevents newm from going into idle states (dimming the screen)",
+    "config": "Reloads the configuration",
+    "lock": "Locks the screen",
+    "clean": "Removes orphaned states, which can happen, but shouldn't (if you encounter the need for this, please file a bug)",
+    "debug": "Prints out some debug info on the current state of views",
+    "finish-inhibit-idle": "Restore the idle states",
+    "close-launcher": "Close launcher",
+    "unlock": "Unlocks the screen",
+}
+
+# Declare new commands, in the following format:
+# "command": {
+#   "help": "description",
+#   "args": {
+#       "arg_name": "description",
+#       ...
+#   }
+# }
+# See main function
+command_needs_args: dict[str, dict[str, Union[str, dict[str, str]]]] = {
+    "open-virtual-output": {
+        "help": "opens a new virtual output (see newm-sidecar)",
+        "args": {"name": "newm-cmd open-virtual-output <name>"},
+    },
+    "close-virtual-output": {
+        "help": "close a virtual output",
+        "args": {"name": "newm-cmd close-virtual-output <name>"},
+    },
+}
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    for command, help in command_without_args.items():
+        subparsers.add_parser(command, help=help)
+
+    for command, meta in command_needs_args.items():
+        command_parser = subparsers.add_parser(command, help=meta["help"])
+        for argument, help in meta["args"].items():
+            command_parser.add_argument(argument, help=help)
+
+    args = parser.parse_args(argv)
+
+    if args.command in command_without_args.keys():
+        return call_without_args(args.command)
+    elif args.command in command_needs_args.keys():
+        dict_args = vars(args)
+        # dict_args[a] for a in command_needs_args[args.command]["args"].keys()
+        call_with_args(
+            args.command,
+            *tuple(
+                filter(
+                    lambda v: v is not None,
+                    map(
+                        lambda k: dict_args.get(k, None),
+                        command_needs_args[args.command]["args"].keys(),
+                    ),
+                )
+            ),
+        )
+    else:
+        raise NotImplementedError(
+            f"Command {args.command} does not exist.",
+        )
+
+
+def call_without_args(command: str) -> int:
+    cmd(command)
+    return 0
+
+
+def call_with_args(command: str, *args) -> int:
+    cmd(command, *args)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/bin/newm-cmd
+++ b/bin/newm-cmd
@@ -40,12 +40,16 @@ commands: dict[str, dict[str, Union[str, dict[str, str]]]] = {
         "args": {},
     },
     "open-virtual-output": {
-        "help": "opens a new virtual output (see newm-sidecar)",
+        "help": "Opens a new virtual output (see newm-sidecar)",
         "args": {"output_name": "newm-cmd open-virtual-output <name>"},
     },
     "close-virtual-output": {
-        "help": "close a virtual output",
+        "help": "Close a virtual output",
         "args": {"output_name": "newm-cmd close-virtual-output <name>"},
+    },
+    "launcher": {
+        "help": "Open new app",
+        "args": {"app": "newm-cmd launcher <app>"},
     },
 }
 
@@ -63,7 +67,6 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     if args.command in commands.keys():
         dict_args = vars(args)
-        # dict_args[a] for a in command_needs_args[args.command]["args"].keys()
         call_cmd(
             args.command,
             *tuple(

--- a/newm/cmd.py
+++ b/newm/cmd.py
@@ -4,19 +4,20 @@ import time
 
 from .dbus import send_dbus_command
 
+
 def cmd(command: str, *args: str) -> None:
     if command == "inhibit-idle":
         try:
-            send_dbus_command({'cmd': "inhibit-idle"})
+            send_dbus_command({"cmd": "inhibit-idle"})
             while True:
                 time.sleep(10)
         except:
             pass
         finally:
-            send_dbus_command({'cmd': "finish-inhibit-idle"})
+            send_dbus_command({"cmd": "finish-inhibit-idle"})
     elif command == "launcher":
-        send_dbus_command({'cmd': 'launcher', 'app': " ".join(args)})
+        send_dbus_command({"cmd": "launcher", "app": " ".join(args)})
     else:
-        result = send_dbus_command({'cmd': command, 'arg': " ".join(args)})
-        if result is not None and 'msg' in result:
-            print(result['msg'])
+        result = send_dbus_command({"cmd": command, "arg": " ".join(args)})
+        if result is not None and "msg" in result:
+            print(result["msg"])

--- a/newm/layout.py
+++ b/newm/layout.py
@@ -31,13 +31,7 @@ from .dbus import DBusEndpoint, DBusGestureProvider
 from .panel_launcher import PanelsLauncher
 from .auth_backend import AuthBackend
 
-from .widget import (
-    TopBar,
-    BottomBar,
-    Background,
-    Corner,
-    FocusBorders
-)
+from .widget import TopBar, BottomBar, Background, Corner, FocusBorders
 from .overlay import (
     Overlay,
     MoveResizeOverlay,
@@ -49,24 +43,26 @@ from .overlay import (
 
 logger = logging.getLogger(__name__)
 
-conf_pywm = configured_value('pywm', cast(dict[str, Any], {}))
+conf_pywm = configured_value("pywm", cast(dict[str, Any], {}))
 
-conf_outputs = configured_value('outputs', cast(list[dict[str, Any]], []))
+conf_outputs = configured_value("outputs", cast(list[dict[str, Any]], []))
 
-conf_send_fullscreen_to_views = configured_value('view.send_fullscreen', True)
+conf_send_fullscreen_to_views = configured_value("view.send_fullscreen", True)
 
 if TYPE_CHECKING:
     TKeyBindings = Callable[[Layout], list[tuple[str, Callable[[], None]]]]
 else:
-    TKeyBindings = TypeVar('TKeyBindings')
+    TKeyBindings = TypeVar("TKeyBindings")
 
-conf_key_bindings = configured_value('key_bindings', cast(TKeyBindings, lambda layout: []))
+conf_key_bindings = configured_value(
+    "key_bindings", cast(TKeyBindings, lambda layout: [])
+)
 
-conf_anim_t = configured_value('anim_time', .3)
-conf_blend_t = configured_value('blend_time', 1.)
+conf_anim_t = configured_value("anim_time", 0.3)
+conf_blend_t = configured_value("blend_time", 1.0)
 
-conf_idle_times = configured_value('energy.idle_times', [120, 300, 600])
-conf_suspend_command = configured_value('energy.suspend_command', "systemctl suspend")
+conf_idle_times = configured_value("energy.idle_times", [120, 300, 600])
+conf_suspend_command = configured_value("energy.suspend_command", "systemctl suspend")
 
 """
 code == 'lock': Called on lock - idea is to dim the screen now
@@ -78,30 +74,48 @@ code == 'active': Called on activity after idle
 code == 'sleep': Called on sleep - maybe set backlight to zero
 code == 'wakeup': Called on wakeup - maybe blend backlight in (may be called twice)
 """
-conf_idle_callback = configured_value('energy.idle_callback', lambda code: None)
+conf_idle_callback = configured_value("energy.idle_callback", lambda code: None)
 
-conf_on_startup = configured_value('on_startup', lambda: None)
-conf_on_reconfigure = configured_value('on_reconfigure', lambda: None)
-conf_lock_on_wakeup = configured_value('lock_on_wakeup', True)
+conf_on_startup = configured_value("on_startup", lambda: None)
+conf_on_reconfigure = configured_value("on_reconfigure", lambda: None)
+conf_lock_on_wakeup = configured_value("lock_on_wakeup", True)
 
-conf_bar_enabled = configured_value('bar.enabled', True)
+conf_bar_enabled = configured_value("bar.enabled", True)
 
-conf_synchronous_update = configured_value('synchronous_update', lambda: None)
+conf_synchronous_update = configured_value("synchronous_update", lambda: None)
 
-conf_enable_pyevdev_gestures = configured_value('gestures.pyevdev.enabled', False)
-conf_enable_c_gestures = configured_value('gestures.c.enabled', True)
-conf_enable_dbus_gestures = configured_value('gestures.dbus.enabled', True)
+conf_enable_pyevdev_gestures = configured_value("gestures.pyevdev.enabled", False)
+conf_enable_c_gestures = configured_value("gestures.c.enabled", True)
+conf_enable_dbus_gestures = configured_value("gestures.dbus.enabled", True)
 
-conf_enable_unlock_command = configured_value('enable_unlock_command', True)
+conf_enable_unlock_command = configured_value("enable_unlock_command", True)
 
-conf_gesture_binding_swipe_to_zoom = configured_value('gesture_bindings.swipe_to_zoom', (None, 'swipe-4'))
-conf_gesture_binding_swipe = configured_value('gesture_bindings.swipe', (None, 'swipe-3'))
-conf_gesture_binding_move_resize = configured_value('gesture_bindings.move_resize', ('L', 'move-1', 'swipe-2'))
-conf_gesture_binding_launcher = configured_value('gesture_bindings.launcher', (None, 'swipe-5'))
+conf_gesture_binding_swipe_to_zoom = configured_value(
+    "gesture_bindings.swipe_to_zoom", (None, "swipe-4")
+)
+conf_gesture_binding_swipe = configured_value(
+    "gesture_bindings.swipe", (None, "swipe-3")
+)
+conf_gesture_binding_move_resize = configured_value(
+    "gesture_bindings.move_resize", ("L", "move-1", "swipe-2")
+)
+conf_gesture_binding_launcher = configured_value(
+    "gesture_bindings.launcher", (None, "swipe-5")
+)
 
-def _score(i1: float, j1: float, w1: float, h1: float,
-           im: int, jm: int,
-           i2: float, j2: float, w2: float, h2: float) -> float:
+
+def _score(
+    i1: float,
+    j1: float,
+    w1: float,
+    h1: float,
+    im: int,
+    jm: int,
+    i2: float,
+    j2: float,
+    w2: float,
+    h2: float,
+) -> float:
 
     if (i1, j1, w1, h1) == (i2, j2, w2, h2):
         return 1000
@@ -131,7 +145,7 @@ def _score(i1: float, j1: float, w1: float, h1: float,
     if d_i < 0:
         return 1000
 
-    d_j = 0.
+    d_j = 0.0
     if j2 >= j1 + h1:
         d_j = j2 - (j1 + h1)
     elif j1 >= j2 + h2:
@@ -143,10 +157,16 @@ def _score(i1: float, j1: float, w1: float, h1: float,
 
 
 class Animation:
-    def __init__(self,
-                 layout: Layout,
-                 reducer: Callable[[LayoutState], tuple[Optional[LayoutState], Optional[LayoutState]]],
-                 duration: float, then: Optional[Callable[..., None]], overlay_safe: bool=False) -> None:
+    def __init__(
+        self,
+        layout: Layout,
+        reducer: Callable[
+            [LayoutState], tuple[Optional[LayoutState], Optional[LayoutState]]
+        ],
+        duration: float,
+        then: Optional[Callable[..., None]],
+        overlay_safe: bool = False,
+    ) -> None:
         super().__init__()
         self.layout = layout
 
@@ -161,7 +181,7 @@ class Animation:
         self._finish: Optional[float] = None
 
         # Prevent devision by zero
-        self.duration = max(.1, duration)
+        self.duration = max(0.1, duration)
 
         self.then = then
         self.overlay_safe = overlay_safe
@@ -208,7 +228,12 @@ class Animation:
             logger.debug("Animation decided not to take place anymore")
 
     def __str__(self) -> str:
-        return "%s -> %s (%f%s)" % (self._initial_state, self._final_state, self.duration, ", then" if self.then is not None else "")
+        return "%s -> %s (%f%s)" % (
+            self._initial_state,
+            self._final_state,
+            self.duration,
+            ", then" if self.then is not None else "",
+        )
 
 
 class LayoutThread(Thread):
@@ -230,7 +255,10 @@ class LayoutThread(Thread):
 
     def push(self, nxt: Union[Overlay, Animation]) -> None:
         if isinstance(nxt, Overlay):
-            if self._current_ovr is not None or len([x for x in self._pending if isinstance(x, Overlay)]) > 0:
+            if (
+                self._current_ovr is not None
+                or len([x for x in self._pending if isinstance(x, Overlay)]) > 0
+            ):
                 logger.debug("Rejecting queued overlay")
                 return
             else:
@@ -260,7 +288,9 @@ class LayoutThread(Thread):
                             self.layout.start_overlay(self._current_ovr)
                             self.layout.enter_constant_damage()
                     else:
-                        if self._current_anim is None and (self._current_ovr is None or self._pending[0].overlay_safe):
+                        if self._current_anim is None and (
+                            self._current_ovr is None or self._pending[0].overlay_safe
+                        ):
                             logger.debug("Thread: Starting animation...")
                             self._current_anim = self._pending.pop(0)
                             self._current_anim.start()
@@ -276,11 +306,11 @@ class LayoutThread(Thread):
             except Exception:
                 logger.exception("Unexpected during LayoutThread")
 
-            time.sleep(1. / 30.)
+            time.sleep(1.0 / 30.0)
 
 
 class Layout(PyWM[View], Animate[PyWMDownstreamState], Animatable):
-    def __init__(self, debug: bool=False, config_file: Optional[str]=None) -> None:
+    def __init__(self, debug: bool = False, config_file: Optional[str] = None) -> None:
         self._config_file = config_file
         load_config(path_str=self._config_file)
 
@@ -295,7 +325,9 @@ class Layout(PyWM[View], Animate[PyWMDownstreamState], Animatable):
 
         self.gesture_providers: list[GestureProvider] = []
 
-        self.workspaces: list[Workspace] = [Workspace(PyWMOutput("dummy", -1, 1., 1280, 720, (0, 0)), 0, 0, 1280, 720)]
+        self.workspaces: list[Workspace] = [
+            Workspace(PyWMOutput("dummy", -1, 1.0, 1280, 720, (0, 0)), 0, 0, 1280, 720)
+        ]
 
         self.state = LayoutState()
 
@@ -314,16 +346,24 @@ class Layout(PyWM[View], Animate[PyWMDownstreamState], Animatable):
         self._idle_inhibit_user = False
 
         # Workspace cursor is on, Focused workspace override by focused view
-        self._active_workspace: tuple[Workspace, Optional[Workspace]] = self.workspaces[0], None
+        self._active_workspace: tuple[Workspace, Optional[Workspace]] = (
+            self.workspaces[0],
+            None,
+        )
 
     def _setup_workspaces(self) -> None:
         output_conf = conf_outputs()
+
         def disable_anim(output: PyWMOutput) -> bool:
             for o in output_conf:
-                if o['name'] == output.name:
-                    return 'anim' in o and not o['anim']
+                if o["name"] == output.name:
+                    return "anim" in o and not o["anim"]
             return False
-        ws = [Workspace(o, o.pos[0], o.pos[1], o.width, o.height, disable_anim(o)) for o in self.layout]
+
+        ws = [
+            Workspace(o, o.pos[0], o.pos[1], o.width, o.height, disable_anim(o))
+            for o in self.layout
+        ]
         i, j = 0, len(ws) - 1
         while i < len(ws) and j < len(ws) and i < j:
             if ws[i].swallow(ws[j]):
@@ -354,9 +394,8 @@ class Layout(PyWM[View], Animate[PyWMDownstreamState], Animatable):
             while True:
                 if h not in [w._handle for w in self.workspaces]:
                     break
-                h+=1
+                h += 1
             w._handle = h
-
 
         logger.debug("Setup of newm workspaces")
         for w in self.workspaces:
@@ -365,20 +404,24 @@ class Layout(PyWM[View], Animate[PyWMDownstreamState], Animatable):
         self.state = self.state.with_workspaces(self)
         self._update_active_workspace()
 
-
     def _update_active_workspace(self) -> None:
         # Clean
         ws_check1, ws_check2 = self._active_workspace
         if ws_check1._handle not in [w._handle for w in self.workspaces]:
             ws_check1 = self.workspaces[0]
-        if ws_check2 is not None and ws_check2._handle not in [w._handle for w in self.workspaces]:
+        if ws_check2 is not None and ws_check2._handle not in [
+            w._handle for w in self.workspaces
+        ]:
             ws_check2 = None
         self._active_workspace = ws_check1, ws_check2
 
         # Find ws cursor is on
         ws: Optional[Workspace] = None
         for w in self.workspaces:
-            if w.pos_x <= self.cursor_pos[0] < w.pos_x + w.width and w.pos_y <= self.cursor_pos[1] < w.pos_y + w.height:
+            if (
+                w.pos_x <= self.cursor_pos[0] < w.pos_x + w.width
+                and w.pos_y <= self.cursor_pos[1] < w.pos_y + w.height
+            ):
                 ws = w
                 break
 
@@ -393,7 +436,10 @@ class Layout(PyWM[View], Animate[PyWMDownstreamState], Animatable):
     def _setup_widgets(self) -> None:
         def get_workspace_for_output(output: PyWMOutput) -> Workspace:
             for w in self.workspaces:
-                if w.pos_x <= output.pos[0] < w.pos_x + w.width and w.pos_y <= output.pos[1] < w.pos_y + w.height:
+                if (
+                    w.pos_x <= output.pos[0] < w.pos_x + w.width
+                    and w.pos_y <= output.pos[1] < w.pos_y + w.height
+                ):
                     return w
             logger.warn("Workspaces do not cover whole area")
             return self.workspaces[0]
@@ -424,21 +470,26 @@ class Layout(PyWM[View], Animate[PyWMDownstreamState], Animatable):
             self.bottom_bars = []
             self.top_bars = []
 
-        self.backgrounds = [self.create_widget(Background, o, get_workspace_for_output(o)) for o in self.layout]
+        self.backgrounds = [
+            self.create_widget(Background, o, get_workspace_for_output(o))
+            for o in self.layout
+        ]
 
         for o in self.layout:
-            self.corners += [[
-                self.create_widget(Corner, o, True, True),
-                self.create_widget(Corner, o, True, False),
-                self.create_widget(Corner, o, False, True),
-                self.create_widget(Corner, o, False, False)
-            ]]
+            self.corners += [
+                [
+                    self.create_widget(Corner, o, True, True),
+                    self.create_widget(Corner, o, True, False),
+                    self.create_widget(Corner, o, False, True),
+                    self.create_widget(Corner, o, False, False),
+                ]
+            ]
 
         self.focus_borders.update()
 
         self.damage()
 
-    def _setup(self, fallback: bool=True, reconfigure: bool=True) -> None:
+    def _setup(self, fallback: bool = True, reconfigure: bool = True) -> None:
         if reconfigure:
             load_config(fallback=fallback, path_str=self._config_file)
 
@@ -446,9 +497,7 @@ class Layout(PyWM[View], Animate[PyWMDownstreamState], Animatable):
 
         self.key_processor.clear()
         if (kb := conf_key_bindings()) is not None:
-            self.key_processor.register_bindings(
-                *kb(self)
-            )
+            self.key_processor.register_bindings(*kb(self))
 
         # Stop and re-setup Gestures
         for g in self.gesture_providers:
@@ -457,20 +506,38 @@ class Layout(PyWM[View], Animate[PyWMDownstreamState], Animatable):
 
         dbus_gesture_provider: Optional[DBusGestureProvider] = None
         if conf_enable_dbus_gestures():
-            dbus_gesture_provider = DBusGestureProvider(self.dbus_endpoint, self._gesture_provider_callback)
+            dbus_gesture_provider = DBusGestureProvider(
+                self.dbus_endpoint, self._gesture_provider_callback
+            )
             self.dbus_endpoint.set_gesture_provider(dbus_gesture_provider)
 
-        self.gesture_providers = \
-            cast(list[GestureProvider], [ PyEvdevGestureProvider(self._gesture_provider_callback) ] if conf_enable_pyevdev_gestures() else []) + \
-            cast(list[GestureProvider], [ CGestureProvider(self._gesture_provider_callback) ] if conf_enable_c_gestures() else []) + \
-            cast(list[GestureProvider], [ dbus_gesture_provider ] if dbus_gesture_provider is not None else [])
+        self.gesture_providers = (
+            cast(
+                list[GestureProvider],
+                [PyEvdevGestureProvider(self._gesture_provider_callback)]
+                if conf_enable_pyevdev_gestures()
+                else [],
+            )
+            + cast(
+                list[GestureProvider],
+                [CGestureProvider(self._gesture_provider_callback)]
+                if conf_enable_c_gestures()
+                else [],
+            )
+            + cast(
+                list[GestureProvider],
+                [dbus_gesture_provider] if dbus_gesture_provider is not None else [],
+            )
+        )
 
         # Start gesture providers
         for p in self.gesture_providers:
             p.start()
 
         if reconfigure:
-            self.reconfigure(dict(**conf_pywm(), outputs=conf_outputs(), debug=self._debug))
+            self.reconfigure(
+                dict(**conf_pywm(), outputs=conf_outputs(), debug=self._debug)
+            )
 
             for v in self._views.values():
                 v.update()
@@ -478,7 +545,9 @@ class Layout(PyWM[View], Animate[PyWMDownstreamState], Animatable):
     def reducer(self, state: LayoutState) -> PyWMDownstreamState:
         return PyWMDownstreamState(state.lock_perc)
 
-    def animate(self, old_state: LayoutState, new_state: LayoutState, dt: float) -> None:
+    def animate(
+        self, old_state: LayoutState, new_state: LayoutState, dt: float
+    ) -> None:
         cur = self.reducer(old_state)
         nxt = self.reducer(new_state)
 
@@ -507,21 +576,27 @@ class Layout(PyWM[View], Animate[PyWMDownstreamState], Animatable):
 
         # Fade in
         def fade_in() -> None:
-            time.sleep(.5)
-            def reducer(state: LayoutState) -> tuple[Optional[LayoutState], Optional[LayoutState]]:
-                return None, state.copy(background_opacity=1.)
+            time.sleep(0.5)
+
+            def reducer(
+                state: LayoutState,
+            ) -> tuple[Optional[LayoutState], Optional[LayoutState]]:
+                return None, state.copy(background_opacity=1.0)
+
             self.animate_to(reducer, conf_blend_t())
+
         Thread(target=fade_in).start()
 
         # Greeter
         if self.auth_backend.is_greeter():
+
             def greet() -> None:
                 while len([p for p in self.panels() if p.panel == "lock"]) < 1:
-                    time.sleep(.5)
+                    time.sleep(0.5)
                 self.ensure_locked()
                 self.auth_backend.init_session()
-            Thread(target=greet).start()
 
+            Thread(target=greet).start()
 
     def _terminate(self) -> None:
         super().terminate()
@@ -537,27 +612,30 @@ class Layout(PyWM[View], Animate[PyWMDownstreamState], Animatable):
         if self.thread is not None:
             self.thread.stop()
 
-
-    def animate_to(self,
-                   reducer: Callable[[LayoutState], tuple[Optional[LayoutState], Optional[LayoutState]]],
-                   duration: float,
-                   then: Optional[Callable[..., None]]=None,
-                   overlay_safe: bool=False) -> None:
+    def animate_to(
+        self,
+        reducer: Callable[
+            [LayoutState], tuple[Optional[LayoutState], Optional[LayoutState]]
+        ],
+        duration: float,
+        then: Optional[Callable[..., None]] = None,
+        overlay_safe: bool = False,
+    ) -> None:
         self.thread.push(Animation(self, reducer, duration, then, overlay_safe))
-
 
     def update(self, new_state: LayoutState) -> None:
         self.state = new_state
         self.damage()
 
     def _all_animates(self) -> list[Animatable]:
-        return [self,
-                *self._views.values(),
-                *self.backgrounds,
-                *self.top_bars,
-                *self.bottom_bars,
-                self.focus_borders
-                ]
+        return [
+            self,
+            *self._views.values(),
+            *self.backgrounds,
+            *self.top_bars,
+            *self.bottom_bars,
+            self.focus_borders,
+        ]
 
     def do_flush_animation(self) -> None:
         for a in self._all_animates():
@@ -572,13 +650,13 @@ class Layout(PyWM[View], Animate[PyWMDownstreamState], Animatable):
 
     def _trusted_unlock(self) -> None:
         if self.is_locked():
-            def reducer(state: LayoutState) -> tuple[Optional[LayoutState], LayoutState]:
-                return None, state.copy(lock_perc=0., background_opacity=1.)
-            self.animate_to(
-                reducer,
-                conf_anim_t(),
-                lambda: self.update_cursor())
 
+            def reducer(
+                state: LayoutState,
+            ) -> tuple[Optional[LayoutState], LayoutState]:
+                return None, state.copy(lock_perc=0.0, background_opacity=1.0)
+
+            self.animate_to(reducer, conf_anim_t(), lambda: self.update_cursor())
 
     """
     Utilities
@@ -612,8 +690,9 @@ class Layout(PyWM[View], Animate[PyWMDownstreamState], Animatable):
         except Exception:
             return self.workspaces[0], 0, 0, 1, 1
 
-
-    def place_initial(self, workspace: Workspace, ws_state: WorkspaceState, w: int, h: int) -> tuple[int, int]:
+    def place_initial(
+        self, workspace: Workspace, ws_state: WorkspaceState, w: int, h: int
+    ) -> tuple[int, int]:
         """
         Strategy
         - If viewpoint > extent:
@@ -633,7 +712,10 @@ class Layout(PyWM[View], Animate[PyWMDownstreamState], Animatable):
         max_j = math.floor(max_j)
 
         view_min_i, view_min_j = ws_state.i, ws_state.j
-        view_max_i, view_max_j = ws_state.i + ws_state.size - 1, ws_state.j + ws_state.size - 1
+        view_max_i, view_max_j = (
+            ws_state.i + ws_state.size - 1,
+            ws_state.j + ws_state.size - 1,
+        )
         view_min_i = math.floor(view_min_i)
         view_min_j = math.floor(view_min_j)
         view_max_i = math.ceil(view_max_i)
@@ -647,10 +729,10 @@ class Layout(PyWM[View], Animate[PyWMDownstreamState], Animatable):
             place_i, place_j = max(min_i, view_min_i), max_j + 1
         else:
             i, j = ws_state.i, ws_state.j
-            for j, i in product(range(math.floor(j),
-                                    math.ceil(j + ws_state.size)),
-                                range(math.floor(i),
-                                    math.ceil(i + ws_state.size))):
+            for j, i in product(
+                range(math.floor(j), math.ceil(j + ws_state.size)),
+                range(math.floor(i), math.ceil(i + ws_state.size)),
+            ):
                 for jp, ip in product(range(j, j + h), range(i, i + w)):
                     if not ws_state.is_tile_free(ip, jp):
                         break
@@ -676,11 +758,12 @@ class Layout(PyWM[View], Animate[PyWMDownstreamState], Animatable):
     """
     Input
     """
+
     def on_key(self, time_msec: int, keycode: int, state: int, keysyms: str) -> bool:
-        """ 
+        """
         These are processed via on_modifiers
         """
-        if keysyms in [ 'Super_L', 'Super_R', 'Alt_L', 'Alt_R', 'Logo_L', 'Logo_R' ]: 
+        if keysyms in ["Super_L", "Super_R", "Alt_L", "Alt_R", "Logo_L", "Logo_R"]:
             return False
 
         if self.overlay is not None and self.overlay.ready():
@@ -688,12 +771,13 @@ class Layout(PyWM[View], Animate[PyWMDownstreamState], Animatable):
             if self.overlay.on_key(time_msec, keycode, state, keysyms):
                 return True
 
-        return self.key_processor.on_key(state == PYWM_PRESSED,
-                                         keysyms,
-                                         self.modifiers,
-                                         self.is_locked())
+        return self.key_processor.on_key(
+            state == PYWM_PRESSED, keysyms, self.modifiers, self.is_locked()
+        )
 
-    def on_modifiers(self, modifiers: PyWMModifiers, last_modifiers: PyWMModifiers) -> bool:
+    def on_modifiers(
+        self, modifiers: PyWMModifiers, last_modifiers: PyWMModifiers
+    ) -> bool:
 
         if modifiers.pressed(last_modifiers).any():
             """
@@ -747,7 +831,14 @@ class Layout(PyWM[View], Animate[PyWMDownstreamState], Animatable):
 
         return False
 
-    def on_axis(self, time_msec: int, source: int, orientation: int, delta: float, delta_discrete: int) -> bool:
+    def on_axis(
+        self,
+        time_msec: int,
+        source: int,
+        orientation: int,
+        delta: float,
+        delta_discrete: int,
+    ) -> bool:
         if self.is_locked():
             return False
 
@@ -759,8 +850,9 @@ class Layout(PyWM[View], Animate[PyWMDownstreamState], Animatable):
                 break
 
         if self.overlay is not None and self.overlay.ready():
-            return self.overlay.on_axis(time_msec, source, orientation,
-                                        delta, delta_discrete)
+            return self.overlay.on_axis(
+                time_msec, source, orientation, delta, delta_discrete
+            )
 
         return False
 
@@ -768,7 +860,9 @@ class Layout(PyWM[View], Animate[PyWMDownstreamState], Animatable):
     Gestures
     """
 
-    def on_gesture(self, kind: str, time_msec: int, args: list[Union[float, int]]) -> bool:
+    def on_gesture(
+        self, kind: str, time_msec: int, args: list[Union[float, int]]
+    ) -> bool:
         for g in self.gesture_providers:
             res = g.on_pywm_gesture(kind, time_msec, args)
             if res == 2:
@@ -791,8 +885,10 @@ class Layout(PyWM[View], Animate[PyWMDownstreamState], Animatable):
             logger.debug("...passing to overlay %s", self.overlay)
             return self.overlay.on_gesture(gesture)
         elif self.overlay is None:
-            if self.modifiers.has(conf_gesture_binding_move_resize()[0]) and (gesture.kind == conf_gesture_binding_move_resize()[1] or 
-                    gesture.kind == conf_gesture_binding_move_resize()[2]):
+            if self.modifiers.has(conf_gesture_binding_move_resize()[0]) and (
+                gesture.kind == conf_gesture_binding_move_resize()[1]
+                or gesture.kind == conf_gesture_binding_move_resize()[2]
+            ):
                 logger.debug("...MoveResize")
                 view = self.find_focused_view()
 
@@ -809,22 +905,33 @@ class Layout(PyWM[View], Animate[PyWMDownstreamState], Animatable):
                     self.enter_overlay(ovr)
                     return True
 
-            if self.modifiers.has(conf_gesture_binding_swipe()[0]) and gesture.kind == conf_gesture_binding_swipe()[1]:
+            if (
+                self.modifiers.has(conf_gesture_binding_swipe()[0])
+                and gesture.kind == conf_gesture_binding_swipe()[1]
+            ):
                 logger.debug("...Swipe")
                 ovr = SwipeOverlay(self)
                 ovr.on_gesture(gesture)
                 self.enter_overlay(ovr)
                 return True
 
-            if not self.state.get_workspace_state(self.get_active_workspace()).is_in_overview():
-                if self.modifiers.has(conf_gesture_binding_swipe_to_zoom()[0]) and gesture.kind == conf_gesture_binding_swipe_to_zoom()[1]:
+            if not self.state.get_workspace_state(
+                self.get_active_workspace()
+            ).is_in_overview():
+                if (
+                    self.modifiers.has(conf_gesture_binding_swipe_to_zoom()[0])
+                    and gesture.kind == conf_gesture_binding_swipe_to_zoom()[1]
+                ):
                     logger.debug("...SwipeToZoom")
                     ovr = SwipeToZoomOverlay(self)
                     ovr.on_gesture(gesture)
                     self.enter_overlay(ovr)
                     return True
 
-            if self.modifiers.has(conf_gesture_binding_launcher()[0]) and gesture.kind == conf_gesture_binding_launcher()[1]:
+            if (
+                self.modifiers.has(conf_gesture_binding_launcher()[0])
+                and gesture.kind == conf_gesture_binding_launcher()[1]
+            ):
                 logger.debug("...Launcher")
                 ovr = LauncherOverlay(self)
                 ovr.on_gesture(gesture)
@@ -832,7 +939,6 @@ class Layout(PyWM[View], Animate[PyWMDownstreamState], Animatable):
                 return True
 
         return False
-
 
     def on_idle(self, elapsed: float, idle_inhibited: bool) -> None:
         idle_inhibited = idle_inhibited or self._idle_inhibit_user
@@ -845,7 +951,7 @@ class Layout(PyWM[View], Animate[PyWMDownstreamState], Animatable):
         elif len(conf_idle_times()) > 2 and elapsed > conf_idle_times()[2]:
             conf_idle_callback()("idle-suspend")
             os.system(conf_suspend_command())
-        elif len(conf_idle_times()) > 2 and elapsed > conf_idle_times()[2] - 5.:
+        elif len(conf_idle_times()) > 2 and elapsed > conf_idle_times()[2] - 5.0:
             conf_idle_callback()("idle-presuspend")
         elif len(conf_idle_times()) > 1 and elapsed > conf_idle_times()[1]:
             conf_idle_callback()("idle-lock")
@@ -882,8 +988,8 @@ class Layout(PyWM[View], Animate[PyWMDownstreamState], Animatable):
             self.overlay.destroy()
         finally:
             self.overlay = None
-    # END DEBUG
 
+    # END DEBUG
 
     def exit_overlay(self) -> None:
         logger.debug("Going to exit overlay...")
@@ -901,7 +1007,6 @@ class Layout(PyWM[View], Animate[PyWMDownstreamState], Animatable):
 
         logger.debug("Resetting gesture")
         self.reset_gesture()
-
 
     def destroy_view(self, view: View) -> None:
         logger.info("Destroying view %s", view)
@@ -926,7 +1031,7 @@ class Layout(PyWM[View], Animate[PyWMDownstreamState], Animatable):
                     best_view = p._handle
 
             if best_view is None:
-                best_view_score = 1000.
+                best_view_score = 1000.0
                 for k, s in ws_state._view_states.items():
                     if not s.is_tiled:
                         continue
@@ -936,13 +1041,18 @@ class Layout(PyWM[View], Animate[PyWMDownstreamState], Animatable):
 
                     i, j, w, h = state.i, state.j, state.w, state.h
                     if state.is_layer:
-                        i, j = ws_state.i + .5*ws_state.size, ws_state.j + .5*ws_state.size
+                        i, j = (
+                            ws_state.i + 0.5 * ws_state.size,
+                            ws_state.j + 0.5 * ws_state.size,
+                        )
                         w, h = 0, 0
                     elif not state.is_tiled:
                         i, j = state.float_pos
                         w, h = 0, 0
 
-                    sc = (s.i - i + s.w / 2. - w / 2.)**2 + (s.j - j + s.h / 2. - h / 2.)**2
+                    sc = (s.i - i + s.w / 2.0 - w / 2.0) ** 2 + (
+                        s.j - j + s.h / 2.0 - h / 2.0
+                    ) ** 2
                     logger.debug("View (%d) has score %f", k, sc)
                     if sc < best_view_score:
                         best_view_score = sc
@@ -951,42 +1061,46 @@ class Layout(PyWM[View], Animate[PyWMDownstreamState], Animatable):
         if best_view is not None and best_view in self._views:
             logger.debug("Found view to focus: %s" % self._views[best_view])
             bv: int = best_view
-            def reducer(state: LayoutState) -> tuple[Optional[LayoutState], LayoutState]:
-                try:
-                    state = state\
-                        .unswallowing(view)\
-                        .focusing_view(self._views[bv])\
-                        .without_view_state(view)\
-                        .constrain()
 
-                    self.focus_borders.update_focus(self._views[bv], present_states=(None, state))
+            def reducer(
+                state: LayoutState,
+            ) -> tuple[Optional[LayoutState], LayoutState]:
+                try:
+                    state = (
+                        state.unswallowing(view)
+                        .focusing_view(self._views[bv])
+                        .without_view_state(view)
+                        .constrain()
+                    )
+
+                    self.focus_borders.update_focus(
+                        self._views[bv], present_states=(None, state)
+                    )
                     self._views[bv].focus()
 
                 except:
                     """
                     View might not exist anymore
                     """
-                    state = state\
-                        .unswallowing(view)\
-                        .without_view_state(view)\
-                        .constrain()
+                    state = (
+                        state.unswallowing(view).without_view_state(view).constrain()
+                    )
 
                     self.focus_borders.unfocus()
 
                 return None, state
 
-            self.animate_to(
-                reducer,
-                conf_anim_t())
+            self.animate_to(reducer, conf_anim_t())
         else:
             if view.is_focused():
                 self.focus_borders.unfocus()
             self.animate_to(
-                lambda state: (None, state
-                    .unswallowing(view)\
-                    .without_view_state(view)
-                    .constrain()),
-                conf_anim_t())
+                lambda state: (
+                    None,
+                    state.unswallowing(view).without_view_state(view).constrain(),
+                ),
+                conf_anim_t(),
+            )
 
     def focus_hint(self, view: View) -> None:
         try:
@@ -1000,35 +1114,40 @@ class Layout(PyWM[View], Animate[PyWMDownstreamState], Animatable):
         except Exception:
             logger.warn("Missing state: %s" % self)
 
-    def command(self, cmd: str, arg: Optional[str]=None) -> Optional[str]:
+    def command(self, cmd: str, arg: Optional[str] = None) -> Optional[str]:
         logger.debug(f"Received command {cmd}")
 
         def set_inhibit_idle(status: bool) -> None:
             self._idle_inhibit_user = status
 
-        def lock() -> None:
-            self._update_idle(True)
-            self.ensure_locked(anim=False)
-
         def clean() -> None:
-            def reducer(state: LayoutState) -> tuple[Optional[LayoutState], LayoutState]:
+            def reducer(
+                state: LayoutState,
+            ) -> tuple[Optional[LayoutState], LayoutState]:
                 new_state = state.copy().clean(list(self._views.keys()))
                 return None, new_state
+
             self.animate_to(reducer, conf_anim_t())
 
         cmds: dict[str, Callable[[], Optional[str]]] = {
             "lock": self.ensure_locked,
-            "lock-pre": lambda: self.ensure_locked(anim=False),
-            "lock-post": lock,
             "config": print_config,
             "debug": self.debug_str,
             "inhibit-idle": lambda: set_inhibit_idle(True),
             "finish-inhibit-idle": lambda: set_inhibit_idle(False),
-            "close-launcher": lambda: self.exit_overlay() if isinstance(self.overlay, LauncherOverlay) else None,
-            "open-virtual-output": lambda: self.open_virtual_output(arg) if arg is not None else None,
-            "close-virtual-output": lambda: self.close_virtual_output(arg) if arg is not None else None,
+            "close-launcher": lambda: self.exit_overlay()
+            if isinstance(self.overlay, LauncherOverlay)
+            else None,
+            "open-virtual-output": lambda: self.open_virtual_output(arg)
+            if arg is not None
+            else None,
+            "close-virtual-output": lambda: self.close_virtual_output(arg)
+            if arg is not None
+            else None,
             "clean": clean,
-            "unlock": self._trusted_unlock if conf_enable_unlock_command() else lambda: "Disabled"
+            "unlock": self._trusted_unlock
+            if conf_enable_unlock_command()
+            else lambda: "Disabled",
         }
         return cmds.get(cmd, lambda: f"Unknown command {cmd}")()
 
@@ -1049,27 +1168,43 @@ class Layout(PyWM[View], Animate[PyWMDownstreamState], Animatable):
             logger.warn("Missing state: %s" % self)
             return False
 
-
     """
     API to be used for configuration
     1. Getters
     """
+
     def get_active_workspace(self) -> Workspace:
         if self._active_workspace[1] is not None:
             return self._active_workspace[1]
         return self._active_workspace[0]
 
-    def tiles(self, workspace: Optional[Workspace]=None) -> list[View]:
-        return [v for _, v in self._views.items() if v.is_tiled(self.state) and self.is_view_on_workspace(v, workspace)]
+    def tiles(self, workspace: Optional[Workspace] = None) -> list[View]:
+        return [
+            v
+            for _, v in self._views.items()
+            if v.is_tiled(self.state) and self.is_view_on_workspace(v, workspace)
+        ]
 
-    def floats(self, workspace: Optional[Workspace]=None) -> list[View]:
-        return [v for _, v in self._views.items() if v.is_float(self.state) and self.is_view_on_workspace(v, workspace)]
+    def floats(self, workspace: Optional[Workspace] = None) -> list[View]:
+        return [
+            v
+            for _, v in self._views.items()
+            if v.is_float(self.state) and self.is_view_on_workspace(v, workspace)
+        ]
 
-    def panels(self, workspace: Optional[Workspace]=None) -> list[View]:
-        return [v for _, v in self._views.items() if v.is_panel() and self.is_view_on_workspace(v, workspace)]
+    def panels(self, workspace: Optional[Workspace] = None) -> list[View]:
+        return [
+            v
+            for _, v in self._views.items()
+            if v.is_panel() and self.is_view_on_workspace(v, workspace)
+        ]
 
-    def views(self, workspace: Optional[Workspace]=None) -> list[View]:
-        return [v for _, v in self._views.items() if not v.is_panel() and self.is_view_on_workspace(v, workspace)]
+    def views(self, workspace: Optional[Workspace] = None) -> list[View]:
+        return [
+            v
+            for _, v in self._views.items()
+            if not v.is_panel() and self.is_view_on_workspace(v, workspace)
+        ]
 
     def find_focused_view(self) -> Optional[View]:
         for _, view in self._views.items():
@@ -1081,13 +1216,14 @@ class Layout(PyWM[View], Animate[PyWMDownstreamState], Animatable):
     """
     2. General purpose methods
     """
+
     def update_config(self) -> None:
         self._setup(fallback=False)
         self.damage()
 
         conf_on_reconfigure()()
 
-    def ensure_locked(self, anim: bool=True, dim: bool=False) -> None:
+    def ensure_locked(self, anim: bool = True, dim: bool = False) -> None:
         def focus_lock() -> None:
             lock_screen = [v for v in self.panels() if v.panel == "lock"]
             if len(lock_screen) > 0:
@@ -1098,43 +1234,64 @@ class Layout(PyWM[View], Animate[PyWMDownstreamState], Animatable):
         self.auth_backend.lock()
 
         def reducer(state: LayoutState) -> tuple[Optional[LayoutState], LayoutState]:
-            return None if anim else state.copy(lock_perc=1., background_opacity=.5), state.copy(lock_perc=1., background_opacity=.5)
-        self.animate_to(
-            reducer,
-            conf_anim_t(), focus_lock)
+            return None if anim else state.copy(
+                lock_perc=1.0, background_opacity=0.5
+            ), state.copy(lock_perc=1.0, background_opacity=0.5)
+
+        self.animate_to(reducer, conf_anim_t(), focus_lock)
 
         if dim:
             conf_idle_callback()("lock")
 
     def terminate(self) -> None:
-        def reducer(state: LayoutState) -> tuple[Optional[LayoutState], Optional[LayoutState]]:
-            return state.copy(final=True), state.copy(final=True, background_opacity=0.)
+        def reducer(
+            state: LayoutState,
+        ) -> tuple[Optional[LayoutState], Optional[LayoutState]]:
+            return state.copy(final=True), state.copy(
+                final=True, background_opacity=0.0
+            )
+
         self.animate_to(reducer, conf_blend_t(), self._terminate)
 
     """
     3. Change global or workspace state / move viewpoint
     """
+
     def enter_launcher_overlay(self) -> None:
         self.enter_overlay(LauncherOverlay(self))
 
-    def toggle_overview(self, only_active_workspace: bool=False) -> None:
-        def reducer(state: LayoutState) -> tuple[Optional[LayoutState], Optional[LayoutState]]:
+    def toggle_overview(self, only_active_workspace: bool = False) -> None:
+        def reducer(
+            state: LayoutState,
+        ) -> tuple[Optional[LayoutState], Optional[LayoutState]]:
             if only_active_workspace:
-                overview = not state.get_workspace_state(self.get_active_workspace()).is_in_overview()
+                overview = not state.get_workspace_state(
+                    self.get_active_workspace()
+                ).is_in_overview()
             else:
                 overview = not state.all_in_overview()
 
             focused: Optional[View] = None
             if not overview:
                 focused = self.find_focused_view()
-            return None, state.with_overview_set(overview, None if not only_active_workspace else self.get_active_workspace(), focused)
+            return None, state.with_overview_set(
+                overview,
+                None if not only_active_workspace else self.get_active_workspace(),
+                focused,
+            )
+
         self.animate_to(reducer, conf_anim_t())
 
     def toggle_fullscreen(self, defined_state: Optional[bool] = None) -> None:
         active_ws = self.get_active_workspace()
-        def reducer(state: LayoutState) -> tuple[Optional[LayoutState], Optional[LayoutState]]:
+
+        def reducer(
+            state: LayoutState,
+        ) -> tuple[Optional[LayoutState], Optional[LayoutState]]:
             if state.get_workspace_state(self.get_active_workspace()).is_in_overview():
-                state = state.with_overview_set(False, only_workspace=self.get_active_workspace())
+                state = state.with_overview_set(
+                    False, only_workspace=self.get_active_workspace()
+                )
 
             view = self.find_focused_view()
 
@@ -1163,34 +1320,49 @@ class Layout(PyWM[View], Animate[PyWMDownstreamState], Animatable):
                     v.set_fullscreen(not fs)
 
             if fs:
-                return None, state.setting_workspace_state(ws, ws_state.without_fullscreen())
+                return None, state.setting_workspace_state(
+                    ws, ws_state.without_fullscreen()
+                )
             elif view is not None:
-                return None, state.setting_workspace_state(ws, ws_state.with_fullscreen(view))
+                return None, state.setting_workspace_state(
+                    ws, ws_state.with_fullscreen(view)
+                )
             else:
                 return None, None
+
         self.animate_to(reducer, conf_anim_t())
 
     def basic_move(self, delta_i: int, delta_j: int) -> None:
         ws = self.get_active_workspace()
+
         def reducer(state: LayoutState) -> tuple[Optional[LayoutState], LayoutState]:
             ws_state = state.get_workspace_state(ws)
-            return None, state.replacing_workspace_state(ws, i=ws_state.i+delta_i, j=ws_state.j+delta_j)
+            return None, state.replacing_workspace_state(
+                ws, i=ws_state.i + delta_i, j=ws_state.j + delta_j
+            )
+
         self.animate_to(reducer, conf_anim_t())
 
     def basic_scale(self, delta_s: int) -> None:
         ws = self.get_active_workspace()
+
         def reducer(state: LayoutState) -> tuple[Optional[LayoutState], LayoutState]:
             ws_state = state.get_workspace_state(ws)
-            return None, state.replacing_workspace_state(ws, size=max(1, ws_state.size+delta_s))
+            return None, state.replacing_workspace_state(
+                ws, size=max(1, ws_state.size + delta_s)
+            )
+
         self.animate_to(reducer, conf_anim_t())
 
     """
     4. Change focus
     """
+
     def focus_view(self, view: View) -> None:
         def reducer(state: LayoutState) -> tuple[Optional[LayoutState], LayoutState]:
             view.focus()
             return None, state.focusing_view(view)
+
         self.animate_to(reducer, conf_anim_t())
 
     def move_in_stack(self, delta: int) -> None:
@@ -1201,31 +1373,35 @@ class Layout(PyWM[View], Animate[PyWMDownstreamState], Animatable):
         try:
             view_state, ws_state, ws_handle = self.state.find_view(view)
             sid, idx, siz = view_state.stack_data
-            nidx = (idx+1)%siz
-            next_view = [k for k, s in ws_state._view_states.items() if s.stack_data[0] == sid and s.stack_data[1]==nidx]
+            nidx = (idx + 1) % siz
+            next_view = [
+                k
+                for k, s in ws_state._view_states.items()
+                if s.stack_data[0] == sid and s.stack_data[1] == nidx
+            ]
             if len(next_view) > 0 and next_view[0] != view:
                 self._views[next_view[0]].focus()
         except:
             logger.exception("Unexpected")
 
-
     def move(self, delta_i: int, delta_j: int) -> None:
         ws, i, j, w, h = self.find_focused_box()
         ws_state = self.state.get_workspace_state(ws)
 
-        if ((i + w > ws_state.i + ws_state.size and delta_i > 0) or
-                (i < ws_state.i and delta_i < 0) or
-                (j + h > ws_state.j + ws_state.size and delta_j > 0) or
-                (j < ws_state.j and delta_j < 0)):
+        if (
+            (i + w > ws_state.i + ws_state.size and delta_i > 0)
+            or (i < ws_state.i and delta_i < 0)
+            or (j + h > ws_state.j + ws_state.size and delta_j > 0)
+            or (j < ws_state.j and delta_j < 0)
+        ):
 
             vf = self.find_focused_view()
             if vf is not None:
                 self.focus_view(vf)
                 return
 
-
         best_view = None
-        best_view_score = 1000.
+        best_view_score = 1000.0
 
         for k, s in ws_state._view_states.items():
             if not s.is_tiled:
@@ -1239,20 +1415,22 @@ class Layout(PyWM[View], Animate[PyWMDownstreamState], Animatable):
         if best_view is not None:
             self.focus_view(self._views[best_view])
 
-    def move_next_view(self, dv: int=1, active_workspace: bool=True) -> None:
+    def move_next_view(self, dv: int = 1, active_workspace: bool = True) -> None:
         views = self.views(self.get_active_workspace() if active_workspace else None)
         focused_view = self.find_focused_view()
 
         if focused_view is not None and focused_view in views:
             idx = views.index(focused_view)
-            next_view = views[(idx + dv)%len(views)]
+            next_view = views[(idx + dv) % len(views)]
             self.focus_view(next_view)
         elif len(views) > 0:
             self.focus_view(views[0])
 
-    def move_workspace(self, ds: int=1) -> None:
+    def move_workspace(self, ds: int = 1) -> None:
         ws = self.get_active_workspace()
-        i, ws = [(i, w) for i, w in enumerate(self.workspaces) if w._handle == ws._handle][0]
+        i, ws = [
+            (i, w) for i, w in enumerate(self.workspaces) if w._handle == ws._handle
+        ][0]
 
         i = (i + ds) % len(self.workspaces)
         ws_new = self.workspaces[i]
@@ -1270,6 +1448,7 @@ class Layout(PyWM[View], Animate[PyWMDownstreamState], Animatable):
     """
     5. Change focused view
     """
+
     def close_focused_view(self) -> None:
         view = [v for _, v in self._views.items() if v.is_focused()]
         if len(view) == 0:
@@ -1278,7 +1457,9 @@ class Layout(PyWM[View], Animate[PyWMDownstreamState], Animatable):
         view[0].close()
 
     def toggle_focused_view_floating(self) -> None:
-        def reducer(state: LayoutState) -> tuple[Optional[LayoutState], Optional[LayoutState]]:
+        def reducer(
+            state: LayoutState,
+        ) -> tuple[Optional[LayoutState], Optional[LayoutState]]:
             view = self.find_focused_view()
             if view is not None:
                 try:
@@ -1290,20 +1471,30 @@ class Layout(PyWM[View], Animate[PyWMDownstreamState], Animatable):
                     ws_state2 = ws_state.replacing_view_state(view, **s2.__dict__)
                     ws_state2.validate_stack_indices(view)
 
-                    return (state.setting_workspace_state(ws, ws_state1), state.setting_workspace_state(ws, ws_state2))
+                    return (
+                        state.setting_workspace_state(ws, ws_state1),
+                        state.setting_workspace_state(ws, ws_state2),
+                    )
                 except:
                     return (None, state)
             else:
                 return (None, state)
+
         self.animate_to(reducer, conf_anim_t())
 
-    def change_focused_view_workspace(self, ds: int=1) -> None:
-        def reducer(state: LayoutState) -> tuple[Optional[LayoutState], Optional[LayoutState]]:
+    def change_focused_view_workspace(self, ds: int = 1) -> None:
+        def reducer(
+            state: LayoutState,
+        ) -> tuple[Optional[LayoutState], Optional[LayoutState]]:
             view = self.find_focused_view()
             if view is not None:
                 try:
                     s, ws_state, ws_handle = state.find_view(view)
-                    i, ws = [(i, w) for i, w in enumerate(self.workspaces) if w._handle == ws_handle][0]
+                    i, ws = [
+                        (i, w)
+                        for i, w in enumerate(self.workspaces)
+                        if w._handle == ws_handle
+                    ][0]
 
                     if not s.is_tiled:
                         return None, None
@@ -1322,26 +1513,34 @@ class Layout(PyWM[View], Animate[PyWMDownstreamState], Animatable):
                     return (None, state)
             else:
                 return (None, state)
+
         self.animate_to(reducer, conf_anim_t())
 
     def move_focused_view(self, di: int, dj: int) -> None:
-        def reducer(state: LayoutState) -> tuple[Optional[LayoutState], Optional[LayoutState]]:
+        def reducer(
+            state: LayoutState,
+        ) -> tuple[Optional[LayoutState], Optional[LayoutState]]:
             view = self.find_focused_view()
             if view is not None:
                 try:
                     s, ws_state, ws_handle = state.find_view(view)
                     ws = [w for w in self.workspaces if w._handle == ws_handle][0]
-                    ws_state = ws_state.replacing_view_state(view, i=s.i+di, j=s.j+dj).focusing_view(view)
+                    ws_state = ws_state.replacing_view_state(
+                        view, i=s.i + di, j=s.j + dj
+                    ).focusing_view(view)
                     ws_state.validate_stack_indices(view)
                     return (None, state.setting_workspace_state(ws, ws_state))
                 except:
                     return (None, state)
             else:
                 return (None, state)
+
         self.animate_to(reducer, conf_anim_t())
 
     def resize_focused_view(self, di: int, dj: int) -> None:
-        def reducer(state: LayoutState) -> tuple[Optional[LayoutState], Optional[LayoutState]]:
+        def reducer(
+            state: LayoutState,
+        ) -> tuple[Optional[LayoutState], Optional[LayoutState]]:
             view = self.find_focused_view()
             if view is not None:
                 try:
@@ -1358,17 +1557,22 @@ class Layout(PyWM[View], Animate[PyWMDownstreamState], Animatable):
 
                     s, ws_state, ws_handle = state.find_view(view)
                     ws = [w for w in self.workspaces if w._handle == ws_handle][0]
-                    ws_state = ws_state.replacing_view_state(view, i=i, j=j, w=w, h=h).focusing_view(view)
+                    ws_state = ws_state.replacing_view_state(
+                        view, i=i, j=j, w=w, h=h
+                    ).focusing_view(view)
                     state.validate_stack_indices(view)
                     return (None, state.setting_workspace_state(ws, ws_state))
                 except:
                     return (None, state)
             else:
                 return (None, state)
+
         self.animate_to(reducer, conf_anim_t())
 
     def swallow_focused_view(self) -> None:
-        def reducer(state: LayoutState) -> tuple[Optional[LayoutState], Optional[LayoutState]]:
+        def reducer(
+            state: LayoutState,
+        ) -> tuple[Optional[LayoutState], Optional[LayoutState]]:
             view = self.find_focused_view()
             if view is None:
                 return None, None
@@ -1383,7 +1587,14 @@ class Layout(PyWM[View], Animate[PyWMDownstreamState], Animatable):
 
             if view.is_tiled(state):
                 by_state = state.get_view_state(by_view)
-                new_state.update_view_state(view, swallowed=by_view._handle, i=by_state.i, j=by_state.j, w=by_state.w, h=by_state.h)
+                new_state.update_view_state(
+                    view,
+                    swallowed=by_view._handle,
+                    i=by_state.i,
+                    j=by_state.j,
+                    w=by_state.w,
+                    h=by_state.h,
+                )
             else:
                 new_state.update_view_state(view, swallowed=by_view._handle)
             new_state.constrain()
@@ -1398,5 +1609,6 @@ class Layout(PyWM[View], Animate[PyWMDownstreamState], Animatable):
     """
     6. Legacy
     """
+
     def close_view(self) -> None:
         self.close_focused_view()


### PR DESCRIPTION
I rewrote newm-cmd, in order to make it behave like a common terminal tool (showing help, error detection, suggestions). Any suggestions are welcome, I also want to modify newm-panel-basic, but I still have to read how it works, if you want to add another command add the respective subcommand in the command_without_args or command_needs_args variables, depending if it needs arguments or not.

```python
command_without_args: dict[str, str] = {
    "inhibit-idle": "Prevents newm from going into idle states (dimming the screen)",
    "config": "Reloads the configuration",
    "lock": "Locks the screen",
    "clean": "Removes orphaned states, which can happen, but shouldn't (if you encounter the need for this, please file a bug)",
    "debug": "Prints out some debug info on the current state of views",
    "finish-inhibit-idle": "Restore the idle states",
    "close-launcher": "Close launcher",
    "unlock": "Unlocks the screen",
}

command_needs_args: dict[str, dict[str, Union[str, dict[str, str]]]] = {
    "open-virtual-output": {
        "help": "opens a new virtual output (see newm-sidecar)",
        "args": {"name": "newm-cmd open-virtual-output <name>"},
    },
    "close-virtual-output": {
        "help": "close a virtual output",
        "args": {"name": "newm-cmd close-virtual-output <name>"},
    },
}
```