### PR TITLE
Add .desktop entry for display manager

### DIFF
--- a/newm/resources/newm.desktop
+++ b/newm/resources/newm.desktop
@@ -1,0 +1,5 @@
+[Desktop Entry]
+Name=newm
+Comment=A scrolling Wayland compositor
+Exec=start-newm
+Type=Application

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ setup(name='newm',
       author='Jonas Bucher',
       author_email='j.bucher.mn@gmail.com',
       packages=['newm', 'newm.helper', 'newm.resources', 'newm.overlay', 'newm.widget', 'newm.dbus', 'newm.gestures', 'newm.gestures.provider', 'newm_panel_basic'],
-      package_data={'newm.resources': ['wallpaper.jpg']},
+      package_data={'newm.resources': ['wallpaper.jpg', 'newm.desktop']},
       scripts=['bin/start-newm', 'bin/.start-newm', 'bin/newm-cmd', 'bin/newm-panel-basic'],
       install_requires=[
           'pycairo',


### PR DESCRIPTION
I've found newm to work pretty well inside `sddm` at least. There are niceties like `loginctl lock-session` which don't work, but I find it no worse than launching from a TTY.

We'd need to install the file to `/usr/share/wayland-sessions/`, but I think that's best handled when packaging.