### PR TITLE
Make pywm's flake-utils follow this flake's

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -15,21 +15,6 @@
         "type": "github"
       }
     },
-    "flake-utils_2": {
-      "locked": {
-        "lastModified": 1656928814,
-        "narHash": "sha256-RIFfgBuKz6Hp89yRr7+NR5tzIAbn52h8vT6vXkYjZoM=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "7e2a3b3dfd9af950a856d66b0a7d01e3c18aa249",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1659077768,
@@ -48,7 +33,9 @@
     },
     "pywmpkg": {
       "inputs": {
-        "flake-utils": "flake-utils_2",
+        "flake-utils": [
+          "flake-utils"
+        ],
         "nixpkgs": [
           "nixpkgs"
         ]

--- a/flake.nix
+++ b/flake.nix
@@ -8,6 +8,7 @@
 
     pywmpkg.url = "github:jbuchermn/pywm";
     pywmpkg.inputs.nixpkgs.follows = "nixpkgs";
+    pywmpkg.inputs.flake-utils.follows = "flake-utils";
   };
 
   outputs = { self, nixpkgs, pywmpkg, flake-utils }:


### PR DESCRIPTION
This just cleans up `flake.lock` of this flake and of other flakes using newm by removing an unnecessary duplicate input.
Since both this flake and [pywm](https://github.com/jbuchermn/pywm) use the exact same url of flake-utils anyways (`github:numtide/flake-utils`), there really shouldn't be any disadvantage to this change.